### PR TITLE
Fix formatting in JSON seed file for inventory

### DIFF
--- a/database/seed/Inventory.json
+++ b/database/seed/Inventory.json
@@ -2,61 +2,61 @@
   {
     "_id": "69a744b360b0dac919a69030",
     "item": "Pencil",
-    "properties": "[\"Any\", \"other\"]",
+    "properties": ["Any", "other"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69031",
     "item": "Folder",
-    "properties": "[\"green\"]",
+    "properties": ["green"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69032",
     "item": "Colored Pencils",
-    "properties": "[\"24 count or 36 count\", \"Crayola\"]",
+    "properties": ["24 count or 36 count", "Crayola"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69033",
     "item": "Folder",
-    "properties": "[\"red\"]",
+    "properties": ["red"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69034",
     "item": "Pencil",
-    "properties": "[\"#2\", \"sharpened\", \"yellow\", \"Ticonderoga\", \"not mechanical\"]",
+    "properties": ["#2", "sharpened", "yellow", "Ticonderoga", "not mechanical"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69035",
     "item": "Colored Pencils",
-    "properties": "[\"Any\", \"other\"]",
+    "properties": ["Any", "other"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69036",
     "item": "Folder",
-    "properties": "[\"plastic\"]",
+    "properties": ["plastic"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69037",
     "item": "Folder",
-    "properties": "[\"red\", \"plastic\"]",
+    "properties": ["red", "plastic"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69038",
     "item": "Folder",
-    "properties": "[\"blue\", \"plastic\"]",
+    "properties": ["blue", "plastic"],
     "quantity": 0
   },
   {
     "_id": "69a744b360b0dac919a69039",
     "item": "Notebook",
-    "properties": "[\"spiral bound\", \"red\"]",
+    "properties": ["spiral bound", "red"],
     "quantity": 0
   }
 ]


### PR DESCRIPTION
The process of moving from a spreadsheet to JSON includes needing to remove some extra quotes and other formatting weirdness in the array of properties. This commit fixes those problems. I just used find and replace on a few different things to remove extra characters.